### PR TITLE
Fixed layout property bug

### DIFF
--- a/transforms/add-layout-property/README.md
+++ b/transforms/add-layout-property/README.md
@@ -16,6 +16,7 @@ atam-codemod add-layout-property path/of/files/ or/some**/*glob.js
 
 <!--FIXTURES_TOC_START-->
 * [basic](#basic)
+* [component-with-mixin](#component-with-mixin)
 * [import-exist-end](#import-exist-end)
 * [import-property-exist](#import-property-exist)
 <!--FIXTURES_TOC_END-->
@@ -29,7 +30,6 @@ atam-codemod add-layout-property path/of/files/ or/some**/*glob.js
 import Component from '@ember/component';
 import { run } from '@ember/runloop';
 import { set } from '@ember/object';
-import { inject as service } from '@ember/service';
 
 export default Component.extend({
   classNames: ['__page-layout__page-wrapper'],
@@ -58,11 +58,73 @@ export default Component.extend({
 import Component from '@ember/component';
 import { run } from '@ember/runloop';
 import { set } from '@ember/object';
-import { inject as service } from '@ember/service';
 
 import layout from '../../templates/components/file-name';
 
 export default Component.extend({
+  layout,
+  classNames: ['__page-layout__page-wrapper'],
+  classNameBindings: ['sidebarEnabled:sidebar-present'],
+  sidebarEnabled: false,
+  contentSidebarEnabled: false,
+
+  didRender() {
+    this._super(...arguments);
+    this.interactivityTracking.trackOnce('FirstWrapperRender');
+  },
+
+  actions: {
+    showHideSidebar(state) {
+      run.next(() => {
+        set(this, 'sidebarEnabled', state);
+      });
+    }
+  }
+});
+
+```
+---
+<a id="component-with-mixin">**component-with-mixin**</a>
+
+**Input** (<small>[component-with-mixin.input.js](transforms/add-layout-property/__testfixtures__/component-with-mixin.input.js)</small>):
+```js
+import Component from '@ember/component';
+import { run } from '@ember/runloop';
+import { set } from '@ember/object';
+import someMixin from 'path/of/mixin';
+
+export default Component.extend(someMixin, {
+  classNames: ['__page-layout__page-wrapper'],
+  classNameBindings: ['sidebarEnabled:sidebar-present'],
+  sidebarEnabled: false,
+  contentSidebarEnabled: false,
+
+  didRender() {
+    this._super(...arguments);
+    this.interactivityTracking.trackOnce('FirstWrapperRender');
+  },
+
+  actions: {
+    showHideSidebar(state) {
+      run.next(() => {
+        set(this, 'sidebarEnabled', state);
+      });
+    }
+  }
+});
+
+```
+
+**Output** (<small>[component-with-mixin.output.js](transforms/add-layout-property/__testfixtures__/component-with-mixin.output.js)</small>):
+```js
+import Component from '@ember/component';
+import { run } from '@ember/runloop';
+import { set } from '@ember/object';
+import someMixin from 'path/of/mixin';
+
+import layout from '../../templates/components/file-name';
+
+export default Component.extend(someMixin, {
   layout,
   classNames: ['__page-layout__page-wrapper'],
   classNameBindings: ['sidebarEnabled:sidebar-present'],
@@ -92,7 +154,6 @@ export default Component.extend({
 import Component from '@ember/component';
 import { run } from '@ember/runloop';
 import { set } from '@ember/object';
-import { inject as service } from '@ember/service';
 import layout from './template';
 
 export default Component.extend({
@@ -122,7 +183,6 @@ export default Component.extend({
 import Component from '@ember/component';
 import { run } from '@ember/runloop';
 import { set } from '@ember/object';
-import { inject as service } from '@ember/service';
 import layout from '../../templates/components/file-name';
 
 export default Component.extend({
@@ -156,7 +216,6 @@ import Component from '@ember/component';
 import { run } from '@ember/runloop';
 import layout from './template';
 import { set } from '@ember/object';
-import { inject as service } from '@ember/service';
 
 export default Component.extend({
   classNames: ['__page-layout__page-wrapper'],
@@ -185,9 +244,8 @@ export default Component.extend({
 ```js
 import Component from '@ember/component';
 import { run } from '@ember/runloop';
-import { set } from '@ember/object';
-import { inject as service } from '@ember/service';
 import layout from '../../templates/components/file-name';
+import { set } from '@ember/object';
 
 export default Component.extend({
   layout,

--- a/transforms/add-layout-property/__testfixtures__/basic.output.js
+++ b/transforms/add-layout-property/__testfixtures__/basic.output.js
@@ -1,7 +1,6 @@
 import Component from '@ember/component';
 import { run } from '@ember/runloop';
 import { set } from '@ember/object';
-import { inject as service } from '@ember/service';
 
 import layout from '../../templates/components/file-name';
 

--- a/transforms/add-layout-property/__testfixtures__/component-with-mixin.input.js
+++ b/transforms/add-layout-property/__testfixtures__/component-with-mixin.input.js
@@ -1,8 +1,9 @@
 import Component from '@ember/component';
 import { run } from '@ember/runloop';
 import { set } from '@ember/object';
+import someMixin from 'path/of/mixin';
 
-export default Component.extend({
+export default Component.extend(someMixin, {
   classNames: ['__page-layout__page-wrapper'],
   classNameBindings: ['sidebarEnabled:sidebar-present'],
   sidebarEnabled: false,

--- a/transforms/add-layout-property/__testfixtures__/component-with-mixin.options.json
+++ b/transforms/add-layout-property/__testfixtures__/component-with-mixin.options.json
@@ -1,0 +1,3 @@
+{
+  "layoutPath": "../../templates/components/file-name"
+}

--- a/transforms/add-layout-property/__testfixtures__/component-with-mixin.output.js
+++ b/transforms/add-layout-property/__testfixtures__/component-with-mixin.output.js
@@ -1,8 +1,12 @@
 import Component from '@ember/component';
 import { run } from '@ember/runloop';
 import { set } from '@ember/object';
+import someMixin from 'path/of/mixin';
 
-export default Component.extend({
+import layout from '../../templates/components/file-name';
+
+export default Component.extend(someMixin, {
+  layout,
   classNames: ['__page-layout__page-wrapper'],
   classNameBindings: ['sidebarEnabled:sidebar-present'],
   sidebarEnabled: false,

--- a/transforms/add-layout-property/__testfixtures__/import-exist-end.input.js
+++ b/transforms/add-layout-property/__testfixtures__/import-exist-end.input.js
@@ -1,7 +1,6 @@
 import Component from '@ember/component';
 import { run } from '@ember/runloop';
 import { set } from '@ember/object';
-import { inject as service } from '@ember/service';
 import layout from './template';
 
 export default Component.extend({

--- a/transforms/add-layout-property/__testfixtures__/import-exist-end.output.js
+++ b/transforms/add-layout-property/__testfixtures__/import-exist-end.output.js
@@ -1,7 +1,6 @@
 import Component from '@ember/component';
 import { run } from '@ember/runloop';
 import { set } from '@ember/object';
-import { inject as service } from '@ember/service';
 import layout from '../../templates/components/file-name';
 
 export default Component.extend({

--- a/transforms/add-layout-property/index.js
+++ b/transforms/add-layout-property/index.js
@@ -23,7 +23,8 @@ const addLayoutProperty = (j, root) => {
       callee: { object: { name: 'Component' } },
     })
     .get(0);
-  let componentObject = component.node.arguments[0];
+  let componentArguments = component.node.arguments;
+  let componentObject = componentArguments[componentArguments.length - 1];
   let existingLayout = componentObject.properties.findIndex((path) => path.key.name === 'layout');
   if (existingLayout !== -1) {
     componentObject.properties.splice(existingLayout, 1);


### PR DESCRIPTION
Problem:
- The layout property transformation failed when the component extends any mixins. 

Cause:
- We took the first argument in the extend function and added the layout property in the object. 

Solution:
- Now we are taking the last argument since that will always be the object we are rooting for.