### PR TITLE
Added Keep-tests-in-host flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ packages/engines/dashboards-engine/addon/templates/default.hbs
 ...
 ```
 
-### Keep-tests-in-host
-If you don't want to move the tests to the addon initially to avoid the overhead use the `--keep-tests-in-host` or `--ktih` option.
+### skip-tests
+If you don't want to move the tests to the addon initially to avoid the overhead use the `--skip-tests` or `-st` option.
 
 ```
-atam component ui-component/button-component packages/engines/dashboards-engine --keep-tests-in-host
+atam component ui-component/button-component packages/engines/dashboards-engine --skip-tests
 ```
 
 This will move the tests from the original file structure to a new folder under the addon namespace
@@ -134,7 +134,7 @@ Options:
   --dry-run, -d  Dry Run: Verify the movement without executing        [boolean]
   --pods, -p     Specify that the source components use PODS structure
                                                        [boolean] [default: true]
-  --keep-tests-in-host, --ktih  Keep tests in host: Convert and keep the tests in the host app itself? (default: no)        [boolean] [default: false]
+  --skip-tests, -st  Keep tests in host: Convert and keep the tests in the host app itself? (default: no)        [boolean] [default: false]
 
 
 ```

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ packages/engines/dashboards-engine/addon/templates/default.hbs
 ```
 
 ### skip-tests
-If you don't want to move the tests to the addon initially to avoid the overhead use the `--skip-tests` or `-st` option.
+If you don't want to move the tests to the addon initially to avoid the overhead use the `--skip-tests` or `--st` option.
 
 ```
 atam component ui-component/button-component packages/engines/dashboards-engine --skip-tests
@@ -134,7 +134,7 @@ Options:
   --dry-run, -d  Dry Run: Verify the movement without executing        [boolean]
   --pods, -p     Specify that the source components use PODS structure
                                                        [boolean] [default: true]
-  --skip-tests, -st  Keep tests in host: Convert and keep the tests in the host app itself? (default: no)        [boolean] [default: false]
+  --skip-tests, --st  Keep tests in host: Convert and keep the tests in the host app itself? (default: no)        [boolean] [default: false]
 
 
 ```

--- a/README.md
+++ b/README.md
@@ -71,10 +71,28 @@ packages/engines/dashboards-engine/addon/templates/default.hbs
 ...
 ```
 
-### Folder namespace 
-If your source entities are namespaced within a folder you can use the `-f` option to specify the same 
-before copying. 
-Say for example you want to move a component called `widget` from `app/components/dashboards` 
+### Keep-tests-in-host
+If you don't want to move the tests to the addon initially to avoid the overhead use the `--keep-tests-in-host` or `--ktih` option.
+
+```
+atam component ui-component/button-component packages/engines/dashboards-engine --keep-tests-in-host
+```
+
+This will move the tests from the original file structure to a new folder under the addon namespace
+inside the host app test folder:
+
+```
+Moving component-test.js
+-----------------------
+app/tests/integration/components/ui-component/button-component/component-test.js
+app/tests/packages/engines/dashboards-engine/tests/integration/components/ui-component/button-component-test.js
+
+...
+```
+### Folder namespace
+If your source entities are namespaced within a folder you can use the `-f` option to specify the same
+before copying.
+Say for example you want to move a component called `widget` from `app/components/dashboards`
 
 ```
 atam component widget packages/engines/dashboards-engine -f dashboards
@@ -116,6 +134,7 @@ Options:
   --dry-run, -d  Dry Run: Verify the movement without executing        [boolean]
   --pods, -p     Specify that the source components use PODS structure
                                                        [boolean] [default: true]
+  --keep-tests-in-host, --ktih  Keep tests in host: Convert and keep the tests in the host app itself? (default: no)        [boolean] [default: false]
 
 
 ```

--- a/src/commands/adapter.js
+++ b/src/commands/adapter.js
@@ -28,7 +28,7 @@ module.exports.handler = async function handler(options) {
   const moveFile = require('../utils/move-file');
   const createAppExport = require('../utils/create-app-export');
 
-  const { adapterName, destination, adapterFolder, dryRun, deleteSource } = options;
+  const { adapterName, destination, adapterFolder, dryRun } = options;
 
   const adapterPath = 'app/adapters';
   const packagePath = path.join('.', destination) || 'packages/engines';
@@ -39,14 +39,17 @@ module.exports.handler = async function handler(options) {
     : `${adapterPath}/${adapterName}.js`;
   const destadapter = `${packagePath}/addon/adapters/${adapterName}.js`;
 
-  moveFile({
-    deleteSource,
-    fileName: adapterName,
-    sourceFile: sourceadapter,
-    destPath: destadapter,
-    fileType: 'Adapter',
-    dryRun,
-  });
+  moveFile(
+    Object.assign(
+      {
+        fileName: adapterName,
+        sourceFile: sourceadapter,
+        destPath: destadapter,
+        fileType: 'Adapter',
+      },
+      options
+    )
+  );
 
   // Moving adapter tests
   const sourceTest = adapterFolder
@@ -54,14 +57,17 @@ module.exports.handler = async function handler(options) {
     : `tests/unit/adapters/${adapterName}-test.js`;
   const destTest = `${packagePath}/tests/unit/adapters/${adapterName}-test.js`;
 
-  moveFile({
-    deleteSource,
-    fileName: adapterName,
-    sourceFile: sourceTest,
-    destPath: destTest,
-    fileType: 'Adapter Test',
-    dryRun,
-  });
+  moveFile(
+    Object.assign(
+      {
+        fileName: adapterName,
+        sourceFile: sourceTest,
+        destPath: destTest,
+        fileType: 'Adapter Test',
+      },
+      options
+    )
+  );
 
   // Create adapter assets to app folder in addon
 

--- a/src/commands/constant.js
+++ b/src/commands/constant.js
@@ -32,7 +32,7 @@ module.exports.handler = async function handler(options) {
 
   const constantPath = 'app/constants';
 
-  const { constantName, destination, constantFolder, dryRun, deleteSource } = options;
+  const { constantName, destination, constantFolder, dryRun } = options;
 
   const packagePath = path.join('.', destination) || 'packages/engines';
 
@@ -42,15 +42,17 @@ module.exports.handler = async function handler(options) {
     : `${constantPath}/${constantName}.js`;
   const destconstant = `${packagePath}/addon/constants/${constantName}.js`;
 
-  moveFile({
-    deleteSource,
-    fileName: constantName,
-    sourceFile: sourceconstant,
-    destPath: destconstant,
-    fileType: 'Constant',
-    dryRun,
-  });
-
+  moveFile(
+    Object.assign(
+      {
+        fileName: constantName,
+        sourceFile: sourceconstant,
+        destPath: destconstant,
+        fileType: 'Constant',
+      },
+      options
+    )
+  );
   // Create constant assets to app folder in addon
 
   createAppExport({

--- a/src/commands/helper.js
+++ b/src/commands/helper.js
@@ -30,7 +30,7 @@ module.exports.handler = async function handler(options) {
   const createAppExport = require('../utils/create-app-export');
 
   const helperPath = 'app/helpers';
-  const { helperName, destination, helperFolder, dryRun, deleteSource } = options;
+  const { helperName, destination, helperFolder, dryRun } = options;
   const packagePath = path.join('.', destination) || 'packages/engines';
 
   // Moving helper.js
@@ -39,14 +39,17 @@ module.exports.handler = async function handler(options) {
     : `${helperPath}/${helperName}.js`;
   const desthelper = `${packagePath}/addon/helpers/${helperName}.js`;
 
-  moveFile({
-    deleteSource,
-    fileName: helperName,
-    sourceFile: sourcehelper,
-    destPath: desthelper,
-    fileType: 'Helper',
-    dryRun,
-  });
+  moveFile(
+    Object.assign(
+      {
+        fileName: helperName,
+        sourceFile: sourcehelper,
+        destPath: desthelper,
+        fileType: 'Helper',
+      },
+      options
+    )
+  );
 
   // Moving helper tests
   const sourceTest = helperFolder
@@ -54,14 +57,17 @@ module.exports.handler = async function handler(options) {
     : `tests/unit/helpers/${helperName}-test.js`;
   const destTest = `${packagePath}/tests/unit/helpers/${helperName}-test.js`;
 
-  moveFile({
-    deleteSource,
-    fileName: helperName,
-    sourceFile: sourceTest,
-    destPath: destTest,
-    fileType: 'Helper Test',
-    dryRun,
-  });
+  moveFile(
+    Object.assign(
+      {
+        fileName: helperName,
+        sourceFile: sourceTest,
+        destPath: destTest,
+        fileType: 'Helper Test',
+      },
+      options
+    )
+  );
 
   // Create helper assets to app folder in addon
   createAppExport({

--- a/src/commands/mixin.js
+++ b/src/commands/mixin.js
@@ -29,7 +29,7 @@ module.exports.handler = async function handler(options) {
   const moveFile = require('../utils/move-file');
 
   const mixinPath = 'app/mixins';
-  const { mixinFolder, mixinName, destination, dryRun, deleteSource } = options;
+  const { mixinFolder, mixinName, destination } = options;
   const packagePath = path.join('.', destination) || 'packages/engines';
 
   // Moving mixin.js
@@ -38,14 +38,17 @@ module.exports.handler = async function handler(options) {
     : `${mixinPath}/${mixinName}.js`;
   const destmixin = `${packagePath}/addon/mixins/${mixinName}.js`;
 
-  moveFile({
-    deleteSource,
-    fileName: mixinName,
-    sourceFile: sourcemixin,
-    destPath: destmixin,
-    fileType: 'Mixin',
-    dryRun,
-  });
+  moveFile(
+    Object.assign(
+      {
+        fileName: mixinName,
+        sourceFile: sourcemixin,
+        destPath: destmixin,
+        fileType: 'Mixin',
+      },
+      options
+    )
+  );
 
   // Moving mixin tests
   const sourceTest = mixinFolder
@@ -53,12 +56,15 @@ module.exports.handler = async function handler(options) {
     : `tests/unit/mixins/${mixinName}-test.js`;
   const destTest = `${packagePath}/tests/unit/mixins/${mixinName}-test.js`;
 
-  moveFile({
-    deleteSource,
-    fileName: mixinName,
-    sourceFile: sourceTest,
-    destPath: destTest,
-    fileType: 'Mixin Test',
-    dryRun,
-  });
+  moveFile(
+    Object.assign(
+      {
+        fileName: mixinName,
+        sourceFile: sourceTest,
+        destPath: destTest,
+        fileType: 'Mixin Test',
+      },
+      options
+    )
+  );
 };

--- a/src/commands/model.js
+++ b/src/commands/model.js
@@ -31,7 +31,7 @@ module.exports.handler = async function handler(options) {
 
   const modelPath = 'app/models';
 
-  const { modelName, destination, modelFolder, dryRun, deleteSource } = options;
+  const { modelName, destination, modelFolder, dryRun } = options;
   const packagePath = path.join('.', destination) || 'packages/engines';
 
   // Moving model.js
@@ -40,14 +40,17 @@ module.exports.handler = async function handler(options) {
     : `${modelPath}/${modelName}.js`;
   const destmodel = `${packagePath}/addon/models/${modelName}.js`;
 
-  moveFile({
-    deleteSource,
-    fileName: modelName,
-    sourceFile: sourcemodel,
-    destPath: destmodel,
-    fileType: 'Model',
-    dryRun,
-  });
+  moveFile(
+    Object.assign(
+      {
+        fileName: modelName,
+        sourceFile: sourcemodel,
+        destPath: destmodel,
+        fileType: 'Model',
+      },
+      options
+    )
+  );
 
   // Moving model tests
   const sourceTest = modelFolder
@@ -55,14 +58,17 @@ module.exports.handler = async function handler(options) {
     : `tests/unit/models/${modelName}-test.js`;
   const destTest = `${packagePath}/tests/unit/models/${modelName}-test.js`;
 
-  moveFile({
-    deleteSource,
-    fileName: modelName,
-    sourceFile: sourceTest,
-    destPath: destTest,
-    fileType: 'Model Test',
-    dryRun,
-  });
+  moveFile(
+    Object.assign(
+      {
+        fileName: modelName,
+        sourceFile: sourceTest,
+        destPath: destTest,
+        fileType: 'Model Test',
+      },
+      options
+    )
+  );
 
   // Create model assets to app folder in addon
   createAppExport({

--- a/src/commands/route.js
+++ b/src/commands/route.js
@@ -28,7 +28,7 @@ module.exports.handler = async function handler(options) {
   const path = require('path');
   const moveFile = require('../utils/move-file');
 
-  const { routeName, destination, routeFolder, dryRun, deleteSource } = options;
+  const { routeName, destination, routeFolder } = options;
 
   const routePath = 'app/routes';
   const templatePath = 'app/templates';
@@ -43,14 +43,17 @@ module.exports.handler = async function handler(options) {
     : `${routePath}/${routeName}.js`;
   const destRoute = `${packagePath}/addon/routes/${routeName}.js`;
 
-  moveFile({
-    deleteSource,
-    fileName: routeName,
-    sourceFile: sourceRoute,
-    destPath: destRoute,
-    fileType: 'Route',
-    dryRun,
-  });
+  moveFile(
+    Object.assign(
+      {
+        fileName: routeName,
+        sourceFile: sourceRoute,
+        destPath: destRoute,
+        fileType: 'Route',
+      },
+      options
+    )
+  );
 
   // Moving route template.hbs
   const sourceTemplate = routeFolder
@@ -59,28 +62,35 @@ module.exports.handler = async function handler(options) {
 
   const destTemplate = `${packagePath}/addon/templates/${routeName}.hbs`;
 
-  moveFile({
-    deleteSource,
-    fileName: routeName,
-    sourceFile: sourceTemplate,
-    destPath: destTemplate,
-    fileType: 'Route Template',
-    dryRun,
-  });
+  moveFile(
+    Object.assign(
+      {
+        fileName: routeName,
+        sourceFile: sourceTemplate,
+        destPath: destTemplate,
+        fileType: 'Route Template',
+      },
+      options
+    )
+  );
 
   // Moving route tests
   const sourceTest = routeFolder
     ? `${testPath}/${routeFolder}/${routeName}-test.js`
     : `${testPath}/${routeName}-test.js`;
   const destTest = `${packagePath}/tests/unit/routes/${routeName}-test.js`;
-  moveFile({
-    deleteSource,
-    fileName: routeName,
-    sourceFile: sourceTest,
-    destPath: destTest,
-    fileType: 'Route Test',
-    dryRun,
-  });
+
+  moveFile(
+    Object.assign(
+      {
+        fileName: routeName,
+        sourceFile: sourceTest,
+        destPath: destTest,
+        fileType: 'Route Test',
+      },
+      options
+    )
+  );
 
   // Move the controllers
   const sourceController = routeFolder
@@ -88,14 +98,17 @@ module.exports.handler = async function handler(options) {
     : `${controllerPath}/${routeName}.js`;
   const destController = `${packagePath}/addon/controllers/${routeName}.js`;
 
-  moveFile({
-    deleteSource,
-    fileName: routeName,
-    sourceFile: sourceController,
-    destPath: destController,
-    fileType: 'Controller',
-    dryRun,
-  });
+  moveFile(
+    Object.assign(
+      {
+        fileName: routeName,
+        sourceFile: sourceController,
+        destPath: destController,
+        fileType: 'Controller',
+      },
+      options
+    )
+  );
 
   // Moving controller tests
   const sourceControllerTest = routeFolder
@@ -103,12 +116,15 @@ module.exports.handler = async function handler(options) {
     : `${controllerTestPath}/${routeName}-test.js`;
   const destControllerTest = `${packagePath}/tests/unit/controllers/${routeName}-test.js`;
 
-  moveFile({
-    deleteSource,
-    fileName: routeName,
-    sourceFile: sourceControllerTest,
-    destPath: destControllerTest,
-    fileType: 'Controller Test',
-    dryRun,
-  });
+  moveFile(
+    Object.assign(
+      {
+        fileName: routeName,
+        sourceFile: sourceControllerTest,
+        destPath: destControllerTest,
+        fileType: 'Controller Test',
+      },
+      options
+    )
+  );
 };

--- a/src/commands/routex.js
+++ b/src/commands/routex.js
@@ -33,7 +33,7 @@ module.exports.handler = async function handler(options) {
 
   const copyComponent = require('../utils/copy-component');
 
-  const { routeName, routeFolder, dryRun, deleteSource } = options;
+  const { routeName, routeFolder, dryRun, deleteSource, keepTestsInHost } = options;
   const templatePath = 'app/templates/helpdesk';
 
   // Moving route.js
@@ -114,6 +114,7 @@ module.exports.handler = async function handler(options) {
             // addonName,
             dryRun,
             deleteSource,
+            keepTestsInHost,
           };
 
           copyComponent(opts);

--- a/src/commands/routex.js
+++ b/src/commands/routex.js
@@ -33,7 +33,7 @@ module.exports.handler = async function handler(options) {
 
   const copyComponent = require('../utils/copy-component');
 
-  const { routeName, routeFolder, dryRun, deleteSource, keepTestsInHost } = options;
+  const { routeName, routeFolder, dryRun, deleteSource, skipTests } = options;
   const templatePath = 'app/templates/helpdesk';
 
   // Moving route.js
@@ -114,7 +114,7 @@ module.exports.handler = async function handler(options) {
             // addonName,
             dryRun,
             deleteSource,
-            keepTestsInHost,
+            skipTests,
           };
 
           copyComponent(opts);

--- a/src/commands/service.js
+++ b/src/commands/service.js
@@ -28,7 +28,7 @@ module.exports.handler = async function handler(options) {
   const moveFile = require('../utils/move-file');
   const createAppExport = require('../utils/create-app-export');
 
-  const { serviceName, destination, serviceFolder, dryRun, deleteSource } = options;
+  const { serviceName, destination, serviceFolder, dryRun } = options;
 
   const servicePath = 'app/services';
   const packagePath = path.join('.', destination) || 'packages/engines';
@@ -39,14 +39,17 @@ module.exports.handler = async function handler(options) {
     : `${servicePath}/${serviceName}.js`;
   const destservice = `${packagePath}/addon/services/${serviceName}.js`;
 
-  moveFile({
-    deleteSource,
-    fileName: serviceName,
-    sourceFile: sourceservice,
-    destPath: destservice,
-    fileType: 'Service',
-    dryRun,
-  });
+  moveFile(
+    Object.assign(
+      {
+        fileName: serviceName,
+        sourceFile: sourceservice,
+        destPath: destservice,
+        fileType: 'Service',
+      },
+      options
+    )
+  );
 
   // Moving service tests
   const sourceTest = serviceFolder
@@ -54,14 +57,17 @@ module.exports.handler = async function handler(options) {
     : `tests/unit/services/${serviceName}-test.js`;
   const destTest = `${packagePath}/tests/unit/services/${serviceName}-test.js`;
 
-  moveFile({
-    deleteSource,
-    fileName: serviceName,
-    sourceFile: sourceTest,
-    destPath: destTest,
-    fileType: 'Service',
-    dryRun,
-  });
+  moveFile(
+    Object.assign(
+      {
+        fileName: serviceName,
+        sourceFile: sourceTest,
+        destPath: destTest,
+        fileType: 'Service',
+      },
+      options
+    )
+  );
 
   // Create service assets to app folder in addon
 

--- a/src/commands/storage.js
+++ b/src/commands/storage.js
@@ -30,7 +30,7 @@ module.exports.handler = async function handler(options) {
   const moveFile = require('../utils/move-file');
 
   const storagePath = 'app/storages';
-  const { storageName, destination, storageFolder, dryRun, deleteSource } = options;
+  const { storageName, destination, storageFolder } = options;
   const packagePath = path.join('.', destination) || 'packages/engines';
 
   // Moving storage.js
@@ -39,12 +39,15 @@ module.exports.handler = async function handler(options) {
     : `${storagePath}/${storageName}.js`;
   const deststorage = `${packagePath}/app/storages/${storageName}.js`;
 
-  moveFile({
-    deleteSource,
-    fileName: storageName,
-    sourceFile: sourcestorage,
-    destPath: deststorage,
-    fileType: 'Storage',
-    dryRun,
-  });
+  moveFile(
+    Object.assign(
+      {
+        fileName: storageName,
+        sourceFile: sourcestorage,
+        destPath: deststorage,
+        fileType: 'Storage',
+      },
+      options
+    )
+  );
 };

--- a/src/commands/util.js
+++ b/src/commands/util.js
@@ -30,7 +30,7 @@ module.exports.handler = async function handler(options) {
   const createAppExport = require('../utils/create-app-export');
 
   const utilPath = 'app/utils';
-  const { utilName, destination, utilFolder, dryRun, deleteSource } = options;
+  const { utilName, destination, utilFolder, dryRun } = options;
   const packagePath = path.join('.', destination) || 'packages/engines';
 
   // Moving util.js
@@ -39,14 +39,17 @@ module.exports.handler = async function handler(options) {
     : `${utilPath}/${utilName}.js`;
   const destutil = `${packagePath}/addon/utils/${utilName}.js`;
 
-  moveFile({
-    deleteSource,
-    fileName: utilName,
-    sourceFile: sourceutil,
-    destPath: destutil,
-    fileType: 'Util',
-    dryRun,
-  });
+  moveFile(
+    Object.assign(
+      {
+        fileName: utilName,
+        sourceFile: sourceutil,
+        destPath: destutil,
+        fileType: 'Util',
+      },
+      options
+    )
+  );
 
   // Moving util tests
   const sourceTest = utilFolder
@@ -54,14 +57,17 @@ module.exports.handler = async function handler(options) {
     : `tests/unit/utils/${utilName}-test.js`;
   const destTest = `${packagePath}/tests/unit/utils/${utilName}-test.js`;
 
-  moveFile({
-    deleteSource,
-    fileName: utilName,
-    sourceFile: sourceTest,
-    destPath: destTest,
-    fileType: 'Util Test',
-    dryRun,
-  });
+  moveFile(
+    Object.assign(
+      {
+        fileName: utilName,
+        sourceFile: sourceTest,
+        destPath: destTest,
+        fileType: 'Util Test',
+      },
+      options
+    )
+  );
 
   // Create util assets to app folder in addon
 

--- a/src/commands/validator.js
+++ b/src/commands/validator.js
@@ -29,7 +29,7 @@ module.exports.handler = async function handler(options) {
   const moveFile = require('../utils/move-file');
   const createAppExport = require('../utils/create-app-export');
 
-  const { validatorName, destination, validatorFolder, dryRun, deleteSource } = options;
+  const { validatorName, destination, validatorFolder, dryRun } = options;
 
   const validatorPath = 'app/validators';
   const packagePath = path.join('.', destination) || 'packages/engines';
@@ -40,28 +40,35 @@ module.exports.handler = async function handler(options) {
     : `${validatorPath}/${validatorName}.js`;
   const destvalidator = `${packagePath}/addon/validators/${validatorName}.js`;
 
-  moveFile({
-    deleteSource,
-    fileName: validatorName,
-    sourceFile: sourcevalidator,
-    destPath: destvalidator,
-    fileType: 'Validator',
-    dryRun,
-  });
+  moveFile(
+    Object.assign(
+      {
+        fileName: validatorName,
+        sourceFile: sourcevalidator,
+        destPath: destvalidator,
+        fileType: 'Validator',
+      },
+      options
+    )
+  );
 
   // Moving validator tests
   const sourceTest = validatorFolder
     ? `tests/unit/validators/${validatorFolder}/${validatorName}-test.js`
     : `tests/unit/validators/${validatorName}-test.js`;
   const destTest = `${packagePath}/tests/unit/validators/${validatorName}-test.js`;
-  moveFile({
-    deleteSource,
-    fileName: validatorName,
-    sourceFile: sourceTest,
-    destPath: destTest,
-    fileType: 'Validator Test',
-    dryRun,
-  });
+
+  moveFile(
+    Object.assign(
+      {
+        fileName: validatorName,
+        sourceFile: sourceTest,
+        destPath: destTest,
+        fileType: 'Validator Test',
+      },
+      options
+    )
+  );
 
   // Create validator assets to app folder in addon
   createAppExport({

--- a/src/components.js
+++ b/src/components.js
@@ -50,15 +50,22 @@ module.exports.moveComponent = function () {
       message: 'Delete Source? (default: no)',
       default: false,
     },
+    {
+      type: 'confirm',
+      name: 'keepTestsInHost',
+      message: 'Convert and keep the tests in the host app itself? (default: no)',
+      default: false,
+    },
   ];
 
   inquirer.prompt(componentPrompt).then((answers) => {
-    const { componentName, destination, dryRun, deleteSource } = answers;
+    const { componentName, destination, dryRun, deleteSource, keepTestsInHost } = answers;
     command.handler({
       componentName,
       destination,
       dryRun,
       deleteSource,
+      keepTestsInHost,
       pods: true,
     });
   });

--- a/src/components.js
+++ b/src/components.js
@@ -52,20 +52,20 @@ module.exports.moveComponent = function () {
     },
     {
       type: 'confirm',
-      name: 'keepTestsInHost',
+      name: 'skipTests',
       message: 'Convert and keep the tests in the host app itself? (default: no)',
       default: false,
     },
   ];
 
   inquirer.prompt(componentPrompt).then((answers) => {
-    const { componentName, destination, dryRun, deleteSource, keepTestsInHost } = answers;
+    const { componentName, destination, dryRun, deleteSource, skipTests } = answers;
     command.handler({
       componentName,
       destination,
       dryRun,
       deleteSource,
-      keepTestsInHost,
+      skipTests,
       pods: true,
     });
   });

--- a/src/utils/add-default-options.js
+++ b/src/utils/add-default-options.js
@@ -8,4 +8,12 @@ module.exports = function (yargs) {
     type: 'boolean',
     default: false,
   });
+
+  yargs.option('keep-tests-in-host', {
+    alias: 'ktih',
+    demandOption: false,
+    describe: 'Keeps the tests in host app under the addon name',
+    type: 'boolean',
+    default: false,
+  });
 };

--- a/src/utils/add-default-options.js
+++ b/src/utils/add-default-options.js
@@ -9,7 +9,7 @@ module.exports = function (yargs) {
     default: false,
   });
 
-  yargs.option('keep-tests-in-host', {
+  yargs.option('skip-tests', {
     alias: 'ktih',
     demandOption: false,
     describe: 'Keeps the tests in host app under the addon name',

--- a/src/utils/add-default-options.js
+++ b/src/utils/add-default-options.js
@@ -10,7 +10,7 @@ module.exports = function (yargs) {
   });
 
   yargs.option('skip-tests', {
-    alias: 'ktih',
+    alias: 'st',
     demandOption: false,
     describe: 'Keeps the tests in host app under the addon name',
     type: 'boolean',

--- a/src/utils/copy-component.js
+++ b/src/utils/copy-component.js
@@ -13,7 +13,7 @@ const createAppExport = require('./create-app-export');
 
 module.exports = async function (options) {
   const componentPath = 'app/components';
-  const { componentFolder, componentName, destination, dryRun, pods, deleteSource } = options;
+  const { componentFolder, componentName, destination, dryRun, pods } = options;
   const packagePath = path.join('.', destination) || 'packages/engines';
 
   // IMPORTANT NOTE: We're deliberately avoiding POD structure in engines
@@ -45,14 +45,17 @@ module.exports = async function (options) {
   }
   const destTemplate = `${packagePath}/addon/templates/components/${componentName}.hbs`;
 
-  await moveFile({
-    deleteSource,
-    fileName: componentName,
-    sourceFile: sourceComponent,
-    destPath: destComponent,
-    fileType: 'Component',
-    dryRun,
-  });
+  await moveFile(
+    Object.assign(
+      {
+        fileName: componentName,
+        sourceFile: sourceComponent,
+        destPath: destComponent,
+        fileType: 'Component',
+      },
+      options
+    )
+  );
 
   // Modify layout import for addon compoenent
   if (fs.existsSync(sourceTemplate)) {
@@ -68,14 +71,17 @@ module.exports = async function (options) {
     ok(`Success: Added layout property to the ${componentName}.js`);
   }
 
-  moveFile({
-    deleteSource,
-    fileName: componentName,
-    sourceFile: sourceTemplate,
-    destPath: destTemplate,
-    fileType: 'Component Template',
-    dryRun,
-  });
+  moveFile(
+    Object.assign(
+      {
+        fileName: componentName,
+        sourceFile: sourceTemplate,
+        destPath: destTemplate,
+        fileType: 'Component Template',
+      },
+      options
+    )
+  );
 
   // Moving component tests
 
@@ -92,14 +98,17 @@ module.exports = async function (options) {
 
   const destTest = `${packagePath}/tests/integration/components/${componentName}-test.js`;
 
-  moveFile({
-    deleteSource,
-    fileName: componentName,
-    sourceFile: sourceTest,
-    destPath: destTest,
-    fileType: 'Component Test',
-    dryRun,
-  });
+  moveFile(
+    Object.assign(
+      {
+        fileName: componentName,
+        sourceFile: sourceTest,
+        destPath: destTest,
+        fileType: 'Component Test',
+      },
+      options
+    )
+  );
 
   // Create component assets to app folder in addon
   createAppExport({

--- a/src/utils/move-file.js
+++ b/src/utils/move-file.js
@@ -7,17 +7,17 @@ const path = require('path');
 const { log, error, ok, warning } = require('./logging');
 
 module.exports = function (options) {
-  const { fileName, sourceFile, dryRun, deleteSource, fileType, keepTestsInHost } = options;
+  const { fileName, sourceFile, dryRun, deleteSource, fileType, skipTests } = options;
 
   let { destPath } = options;
 
   log(`Moving ${fileType}`);
   log('---------------');
 
-  log(`keepTestsInHost - ${keepTestsInHost}`);
+  log(`skipTests - ${skipTests}`);
   log(`destMatched - ${destPath.match(/\/tests\//g)}`);
 
-  if (keepTestsInHost && destPath.match(/\/tests\//g)) {
+  if (skipTests && destPath.match(/\/tests\//g)) {
     destPath = path.join('tests', destPath);
   }
 

--- a/src/utils/move-file.js
+++ b/src/utils/move-file.js
@@ -2,14 +2,24 @@
 
 const fs = require('fs');
 const fse = require('fs-extra');
+const path = require('path');
 
 const { log, error, ok, warning } = require('./logging');
 
 module.exports = function (options) {
-  const { fileName, sourceFile, destPath, dryRun, deleteSource, fileType } = options;
+  const { fileName, sourceFile, dryRun, deleteSource, fileType, keepTestsInHost } = options;
+
+  let { destPath } = options;
 
   log(`Moving ${fileType}`);
   log('---------------');
+
+  log(`keepTestsInHost - ${keepTestsInHost}`);
+  log(`destMatched - ${destPath.match(/\/tests\//g)}`);
+
+  if (keepTestsInHost && destPath.match(/\/tests\//g)) {
+    destPath = path.join('tests', destPath);
+  }
 
   log(sourceFile);
   log(destPath);

--- a/tests/fixtures/input/packages/engines/dashboards/app/adapters/sample2.js
+++ b/tests/fixtures/input/packages/engines/dashboards/app/adapters/sample2.js
@@ -1,1 +1,1 @@
-export { default } from 'dashboards/adapters/sample2';
+export { default } from '@company/dashboard/adapters/sample2';

--- a/tests/fixtures/input/packages/engines/dashboards/app/constants/sample.js
+++ b/tests/fixtures/input/packages/engines/dashboards/app/constants/sample.js
@@ -1,0 +1,1 @@
+export { default } from '@company/dashboard/constants/sample';

--- a/tests/fixtures/input/packages/engines/dashboards/app/helpers/sample2.js
+++ b/tests/fixtures/input/packages/engines/dashboards/app/helpers/sample2.js
@@ -1,1 +1,1 @@
-export { default } from 'dashboards/helpers/sample2';
+export { default } from '@company/dashboard/helpers/sample2';

--- a/tests/fixtures/input/packages/engines/dashboards/app/models/sample2.js
+++ b/tests/fixtures/input/packages/engines/dashboards/app/models/sample2.js
@@ -1,1 +1,1 @@
-export { default } from 'dashboards/models/sample2';
+export { default } from '@company/dashboard/models/sample2';

--- a/tests/fixtures/input/packages/engines/dashboards/app/services/sample2.js
+++ b/tests/fixtures/input/packages/engines/dashboards/app/services/sample2.js
@@ -1,1 +1,1 @@
-export { default } from 'dashboards/services/sample2';
+export { default } from '@company/dashboard/services/sample2';

--- a/tests/fixtures/input/packages/engines/dashboards/app/utils/sample.js
+++ b/tests/fixtures/input/packages/engines/dashboards/app/utils/sample.js
@@ -1,1 +1,1 @@
-export { default } from 'dashboards/utils/sample';
+export { default } from '@company/dashboard/utils/sample';

--- a/tests/fixtures/input/packages/engines/dashboards/app/utils/sample2.js
+++ b/tests/fixtures/input/packages/engines/dashboards/app/utils/sample2.js
@@ -1,1 +1,1 @@
-export { default } from 'dashboards/utils/sample2';
+export { default } from '@company/dashboard/utils/sample2';

--- a/tests/fixtures/input/packages/engines/dashboards/app/validators/sample2.js
+++ b/tests/fixtures/input/packages/engines/dashboards/app/validators/sample2.js
@@ -1,1 +1,1 @@
-export { default } from 'dashboards/validators/sample2';
+export { default } from '@company/dashboard/validators/sample2';

--- a/tests/fixtures/input/packages/engines/dashboards/package.json
+++ b/tests/fixtures/input/packages/engines/dashboards/package.json
@@ -1,3 +1,3 @@
 {
-  "name": "@freshworks/asset-management"
+  "name": "@company/dashboard"
 }

--- a/tests/utils/move-file-test.js
+++ b/tests/utils/move-file-test.js
@@ -1,0 +1,77 @@
+const QUnit = require('qunit');
+const path = require('path');
+const fs = require('fs-extra');
+
+const MoveFile = require('../../src/utils/move-file');
+
+const FIXTURE_PATH = path.join(__dirname, '..', 'fixtures/input');
+const HOST_TEST_PATH = 'tests';
+
+QUnit.module('atam-cli', function (hooks) {
+  hooks.beforeEach(function () {
+    process.chdir(FIXTURE_PATH);
+  });
+
+  QUnit.module('#keepTestsInHost validator', function () {
+    QUnit.test(
+      'should move the tests inside the addon itself if keepTestsInHost is false',
+      async function (assert) {
+        let sourceFile = 'tests/integration/components/sample3/component-test.js';
+        let destPath = 'packages/engines/dashboards/tests/integration/components/sample3-test.js';
+        let options = {
+          fileName: 'sample3',
+          sourceFile,
+          destPath,
+          fileType: 'Component Test',
+          deleteSource: false,
+          keepTestsInHost: false,
+          dryRun: false,
+        };
+        await MoveFile(options);
+        assert.ok(fs.pathExistsSync(path.join(FIXTURE_PATH, destPath)));
+        await fs.remove(path.join(FIXTURE_PATH, destPath));
+      }
+    );
+
+    QUnit.test(
+      'should move the non test entity inside the addon itself even if keepTestsInHost is true',
+      async function (assert) {
+        let sourceFile = 'app/components/sample3/component.js';
+        let destPath = 'packages/engines/dashboards/addon/components/sample3.js';
+        let options = {
+          fileName: 'sample3',
+          sourceFile,
+          destPath,
+          fileType: 'Component',
+          deleteSource: false,
+          keepTestsInHost: true,
+          dryRun: false,
+        };
+        await MoveFile(options);
+        assert.ok(fs.pathExistsSync(path.join(FIXTURE_PATH, destPath)));
+        await fs.remove(path.join(FIXTURE_PATH, destPath));
+      }
+    );
+
+    QUnit.test(
+      'should move the tests inside the host app under the addon structure if keepTestsInHost is true',
+      async function (assert) {
+        let sourceFile = 'tests/integration/components/sample3/component-test.js';
+        let destPath = 'packages/engines/dashboards/tests/integration/components/sample3-test.js';
+        let options = {
+          fileName: 'sample3',
+          sourceFile,
+          destPath,
+          fileType: 'Component Test',
+          deleteSource: false,
+          keepTestsInHost: true,
+          dryRun: false,
+        };
+        await MoveFile(options);
+        assert.ok(fs.pathExistsSync(path.join(FIXTURE_PATH, HOST_TEST_PATH, destPath)));
+        assert.notOk(fs.pathExistsSync(path.join(FIXTURE_PATH, destPath)));
+        await fs.remove(path.join(FIXTURE_PATH, HOST_TEST_PATH, destPath));
+      }
+    );
+  });
+});

--- a/tests/utils/move-file-test.js
+++ b/tests/utils/move-file-test.js
@@ -12,9 +12,9 @@ QUnit.module('atam-cli', function (hooks) {
     process.chdir(FIXTURE_PATH);
   });
 
-  QUnit.module('#keepTestsInHost validator', function () {
+  QUnit.module('#skipTests validator', function () {
     QUnit.test(
-      'should move the tests inside the addon itself if keepTestsInHost is false',
+      'should move the tests inside the addon itself if skipTests is false',
       async function (assert) {
         let sourceFile = 'tests/integration/components/sample3/component-test.js';
         let destPath = 'packages/engines/dashboards/tests/integration/components/sample3-test.js';
@@ -24,7 +24,7 @@ QUnit.module('atam-cli', function (hooks) {
           destPath,
           fileType: 'Component Test',
           deleteSource: false,
-          keepTestsInHost: false,
+          skipTests: false,
           dryRun: false,
         };
         await MoveFile(options);
@@ -34,7 +34,7 @@ QUnit.module('atam-cli', function (hooks) {
     );
 
     QUnit.test(
-      'should move the non test entity inside the addon itself even if keepTestsInHost is true',
+      'should move the non test entity inside the addon itself even if skipTests is true',
       async function (assert) {
         let sourceFile = 'app/components/sample3/component.js';
         let destPath = 'packages/engines/dashboards/addon/components/sample3.js';
@@ -44,7 +44,7 @@ QUnit.module('atam-cli', function (hooks) {
           destPath,
           fileType: 'Component',
           deleteSource: false,
-          keepTestsInHost: true,
+          skipTests: true,
           dryRun: false,
         };
         await MoveFile(options);
@@ -54,7 +54,7 @@ QUnit.module('atam-cli', function (hooks) {
     );
 
     QUnit.test(
-      'should move the tests inside the host app under the addon structure if keepTestsInHost is true',
+      'should move the tests inside the host app under the addon structure if skipTests is true',
       async function (assert) {
         let sourceFile = 'tests/integration/components/sample3/component-test.js';
         let destPath = 'packages/engines/dashboards/tests/integration/components/sample3-test.js';
@@ -64,7 +64,7 @@ QUnit.module('atam-cli', function (hooks) {
           destPath,
           fileType: 'Component Test',
           deleteSource: false,
-          keepTestsInHost: true,
+          skipTests: true,
           dryRun: false,
         };
         await MoveFile(options);


### PR DESCRIPTION
If the user don't want to move the tests to the addon initially to avoid the overhead he/she use the `--skip-tests` or `--st` option.
  
```
atam component ui-component/button-component packages/engines/dashboards-engine --skip-tests true
```

This will move the tests from the original file structure to a new folder under the addon namespace
inside the host app test folder:

```
Moving component-test.js
-----------------------
app/tests/integration/components/ui-component/button-component/component-test.js
app/tests/packages/engines/dashboards-engine/tests/integration/components/ui-component/button-component-test.js

...
```